### PR TITLE
docs(scope): aktive source-pfade klarstellen und runtime-kontext abgrenzen

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -93,7 +93,7 @@ cat .devcontainer/TROUBLESHOOTING.md
 If the API service fails to start due to missing dependencies:
 
 ```bash
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 # With timeout protection (recommended)
 timeout 120 pip install --user fastapi uvicorn python-dotenv
 # OR for full requirements:
@@ -119,7 +119,7 @@ pwsh .devcontainer/setup-powershell.ps1
 If pip installation times out during setup:
 
 ```bash
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 # The setup script now uses timeout automatically
 timeout 300 pip install --user --timeout 300 -r requirements.txt
 # OR install essentials only:
@@ -130,9 +130,9 @@ pip install --user -r requirements-minimal.txt
 
 The setup automatically creates `.env` files from examples. To customize:
 
-1. **API Configuration**: Edit `api.menschlichkeit-oesterreich.at/.env`
-2. **Frontend Configuration**: Edit `frontend/.env`
-3. **CRM Configuration**: Edit `crm.menschlichkeit-oesterreich.at/.env`
+1. **API Configuration**: Edit `apps/api/.env`
+2. **Website Configuration**: Edit `apps/website/.env.local`
+3. **CRM Configuration**: Review the Drupal/CiviCRM settings under `apps/crm/`
 
 ## 📊 Quality & Testing
 
@@ -194,9 +194,11 @@ For more help, see:
 
 ## 📁 Project Structure
 
-- `frontend/` - React/TypeScript frontend
-- `api.menschlichkeit-oesterreich.at/` - FastAPI Python backend
-- `crm.menschlichkeit-oesterreich.at/` - CiviCRM PHP application
-- `web/` - Educational games
+- `apps/website/` - React/TypeScript frontend
+- `apps/api/` - FastAPI Python backend
+- `apps/crm/` - Drupal 10 + CiviCRM
+- `apps/babylon-game/` - Educational games
 - `automation/n8n/` - Workflow automation
 - `scripts/` - Development and deployment scripts
+
+Hinweis: Domain- oder Mirror-Pfade wie `api.menschlichkeit-oesterreich.at/` und `crm.menschlichkeit-oesterreich.at/` sind keine aktiven lokalen Entwicklungsziele in diesem Repository.

--- a/.devcontainer/TROUBLESHOOTING.md
+++ b/.devcontainer/TROUBLESHOOTING.md
@@ -5,6 +5,7 @@
 ### Problem: Devcontainer startet nicht oder hängt
 
 **Symptome:**
+
 - Codespace öffnet sich nicht vollständig
 - Setup-Prozess bleibt hängen
 - Fehlermeldungen beim Start
@@ -12,15 +13,17 @@
 **Lösung:**
 
 1. **Diagnose ausführen**
+
    ```bash
    bash .devcontainer/diagnose.sh
    ```
 
 2. **Logs überprüfen**
+
    ```bash
    # onCreate Log (falls vorhanden)
    cat /tmp/devcontainer-onCreate-setup.log
-   
+
    # Setup-Test ausführen
    bash .devcontainer/test-setup.sh
    ```
@@ -33,11 +36,13 @@
 ### Problem: Keine Netzwerkverbindung (Offline-Modus)
 
 **Symptome:**
+
 - `Network connectivity failed` Meldungen
 - npm/pip Installation schlägt fehl
 - Git clone/push funktioniert nicht
 
 **Erklärung:**
+
 - Dies ist normal in CI/Test-Umgebungen ohne Internet
 - Setup-Scripts erkennen dies automatisch und arbeiten offline
 
@@ -50,17 +55,18 @@
 # npm Pakete nachinstallieren
 npm install
 
-# Python Pakete nachinstallieren  
+# Python Pakete nachinstallieren
 pip install --user fastapi uvicorn python-dotenv pydantic
 
 # Vollständige API Requirements
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 pip install --user -r app/requirements.txt
 ```
 
 ### Problem: Python Dependencies fehlen (FastAPI/Uvicorn)
 
 **Symptome:**
+
 - `ModuleNotFoundError: No module named 'fastapi'`
 - API-Server startet nicht
 
@@ -74,13 +80,14 @@ pip install --user fastapi uvicorn python-dotenv pydantic
 timeout 120 pip install --user fastapi uvicorn python-dotenv
 
 # Vollständige Requirements (wenn benötigt)
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 timeout 180 pip install --user -r app/requirements.txt
 ```
 
 ### Problem: .env Dateien fehlen
 
 **Symptome:**
+
 - Umgebungsvariablen nicht verfügbar
 - Services starten mit Fehlern
 
@@ -92,13 +99,14 @@ bash .devcontainer/onCreate-setup.sh
 
 # Oder manuell:
 cp .env.example .env
-cp api.menschlichkeit-oesterreich.at/.env.example api.menschlichkeit-oesterreich.at/.env
-cp frontend/.env.example frontend/.env
+cp apps/api/.env.example apps/api/.env
+cp apps/website/.env.example apps/website/.env.local
 ```
 
 ### Problem: npm install schlägt fehl oder hängt
 
 **Symptome:**
+
 - npm install timeout
 - node_modules unvollständig
 - Dependency errors
@@ -123,6 +131,7 @@ npm install --only=production
 ### Problem: Shell-Skripte nicht ausführbar
 
 **Symptome:**
+
 - `Permission denied` beim Ausführen von .sh Dateien
 - Scripts laufen nicht
 
@@ -142,6 +151,7 @@ find . -name "*.sh" -type f -exec chmod +x {} \;
 ### Problem: PowerShell Module fehlen
 
 **Symptome:**
+
 - PowerShell-Funktionen nicht verfügbar
 - Module-Import schlägt fehl
 
@@ -233,12 +243,13 @@ bash .devcontainer/onCreate-setup.sh
 
 # 3. Dependencies neu installieren
 npm install
-cd api.menschlichkeit-oesterreich.at && pip install --user -r app/requirements.txt
+cd apps/api && pip install --user -r app/requirements.txt
 ```
 
 ### Codespace neu erstellen (letzter Ausweg)
 
 Wenn nichts hilft:
+
 1. Codespace löschen (GitHub → Codespaces → Delete)
 2. Neuen Codespace erstellen
 3. Warten bis automatisches Setup abgeschlossen ist
@@ -255,11 +266,12 @@ Wenn nichts hilft:
 ## 🆘 Wenn nichts funktioniert
 
 1. **Issue erstellen**
-   - Repository: github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development
+   - Repository: github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich
    - Template: Bug Report
    - Anhängen: Output von `bash .devcontainer/diagnose.sh`
 
 2. **Direkte Hilfe**
+
    ```bash
    # Manual Setup mit interaktiver Auswahl
    bash .devcontainer/manual-setup.sh

--- a/.github/actions/bsm-env-inject/action.yml
+++ b/.github/actions/bsm-env-inject/action.yml
@@ -123,8 +123,11 @@ runs:
             exit 1
           fi
 
-          # Mask full value and each line to avoid multiline secret leakage in runner env dumps.
-          echo "::add-mask::${value}"
+          # Never pass multiline values directly to add-mask, because command parsing
+          # can emit subsequent lines into logs before masking applies.
+          if [[ "$value" != *$'\n'* ]]; then
+            echo "::add-mask::${value}"
+          fi
           while IFS= read -r line; do
             if [ -n "$line" ]; then
               echo "::add-mask::${line}"

--- a/.github/actions/bsm-env-inject/action.yml
+++ b/.github/actions/bsm-env-inject/action.yml
@@ -123,7 +123,13 @@ runs:
             exit 1
           fi
 
+          # Mask full value and each line to avoid multiline secret leakage in runner env dumps.
           echo "::add-mask::${value}"
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+              echo "::add-mask::${line}"
+            fi
+          done <<< "$value"
           write_multiline_env "$env_var" "$value"
           printf '{"%s":%s}\n' "$env_var" "$(printf '%s' "$value" | jq -Rs '.')" >> "$secret_objects_file"
           injected_names+=("$env_var")

--- a/.github/actions/bsm-env-inject/action.yml
+++ b/.github/actions/bsm-env-inject/action.yml
@@ -42,6 +42,11 @@ runs:
           exit 1
         fi
 
+        if [ "$(jq -r --arg profile "$BSM_PROFILE" 'has("profiles") and (.profiles | has($profile))' "$MAP_FILE")" != "true" ]; then
+          echo "✗ Profil '$BSM_PROFILE' fehlt in $MAP_FILE"
+          exit 1
+        fi
+
         fetch_secret_value() {
           local uuid="$1"
           local json=""
@@ -71,59 +76,100 @@ runs:
           printf '%s' "$value"
         }
 
-        resolve_uuid() {
-          local env_var="$1"
-          jq -r --arg profile "$BSM_PROFILE" --arg env_var "$env_var" '
-            .profiles[$profile].secrets[]?
-            | select(.env_var == $env_var)
-            | .uuid
-          ' "$MAP_FILE" | head -n1
+        write_multiline_env() {
+          local key="$1"
+          local value="$2"
+          local delim="EOF_$(date +%s)_$RANDOM"
+          {
+            printf '%s<<%s\n' "$key" "$delim"
+            printf '%s\n' "$value"
+            printf '%s\n' "$delim"
+          } >> "$GITHUB_ENV"
         }
 
-        TENANT_UUID=$(resolve_uuid "MICROSOFT_TENANT_ID")
-        CLIENT_ID_UUID=$(resolve_uuid "MICROSOFT_CLIENT_ID")
-        CLIENT_SECRET_UUID=$(resolve_uuid "MICROSOFT_CLIENT_SECRET")
-        GRAPH_SENDER_UUID=$(resolve_uuid "MICROSOFT_GRAPH_SENDER")
-        SLACK_WEBHOOK_UUID=$(resolve_uuid "ALERTS_SLACK_WEBHOOK")
+        mapfile -t secret_rows < <(jq -r --arg profile "$BSM_PROFILE" '.profiles[$profile].secrets[]? | @base64' "$MAP_FILE")
 
-        for required_uuid in "$TENANT_UUID" "$CLIENT_ID_UUID" "$CLIENT_SECRET_UUID" "$GRAPH_SENDER_UUID" "$SLACK_WEBHOOK_UUID"; do
-          if [ -z "$required_uuid" ] || [ "$required_uuid" = "null" ]; then
-            echo "✗ Unvollstaendiges Mapping fuer Profil '$BSM_PROFILE'"
+        if [ "${#secret_rows[@]}" -eq 0 ]; then
+          echo "✗ Profil '$BSM_PROFILE' enthält keine Secrets"
+          exit 1
+        fi
+
+        injected_names=()
+        secret_objects_file="$(mktemp)"
+
+        for row in "${secret_rows[@]}"; do
+          entry_json=$(printf '%s' "$row" | base64 --decode)
+          env_var=$(printf '%s' "$entry_json" | jq -r '.env_var // empty')
+          uuid=$(printf '%s' "$entry_json" | jq -r '.uuid // empty')
+
+          if [ -z "$env_var" ]; then
+            echo "✗ Profil '$BSM_PROFILE' enthält Secret ohne env_var"
             exit 1
+          fi
+
+          if [ -z "$uuid" ] || [ "$uuid" = "null" ]; then
+            echo "✗ Secret '$env_var' hat keine UUID im Profil '$BSM_PROFILE'"
+            exit 1
+          fi
+
+          if [[ "$uuid" == "UPDATE_VALUE_IN_VAULT" || "$uuid" == PLACEHOLDER_* ]]; then
+            echo "✗ Secret '$env_var' hat Platzhalter-UUID im Profil '$BSM_PROFILE'"
+            exit 1
+          fi
+
+          value=$(fetch_secret_value "$uuid")
+          if [ -z "$value" ]; then
+            echo "✗ Secret '$env_var' ist leer im Profil '$BSM_PROFILE'"
+            exit 1
+          fi
+
+          echo "::add-mask::${value}"
+          write_multiline_env "$env_var" "$value"
+          printf '{"%s":%s}\n' "$env_var" "$(printf '%s' "$value" | jq -Rs '.')" >> "$secret_objects_file"
+          injected_names+=("$env_var")
+        done
+
+        secrets_json=$(jq -sc 'add // {}' "$secret_objects_file")
+        if [ "$BSM_PROFILE" = "deploy-production" ]; then
+          required_keys=(
+            DATABASE_URL
+            JWT_SECRET_KEY
+            STRIPE_SECRET_KEY
+            STRIPE_WEBHOOK_SECRET
+            MOE_API_TOKEN
+            N8N_WEBHOOK_SECRET
+            CIVICRM_SITE_KEY
+            CIVICRM_API_KEY
+            ALERTS_SLACK_WEBHOOK
+            MICROSOFT_TENANT_ID
+            MICROSOFT_CLIENT_ID
+            MICROSOFT_CLIENT_SECRET
+            MICROSOFT_GRAPH_SENDER
+          )
+
+          for required_key in "${required_keys[@]}"; do
+            required_value=$(printf '%s' "$secrets_json" | jq -r --arg key "$required_key" '.[$key] // empty')
+            if [ -z "$required_value" ]; then
+              echo "✗ Pflicht-Secret '$required_key' fehlt im Profil '$BSM_PROFILE'"
+              exit 1
+            fi
+          done
+        fi
+
+        injected_csv=""
+        for name in "${injected_names[@]}"; do
+          if [ -z "$injected_csv" ]; then
+            injected_csv="$name"
+          else
+            injected_csv="$injected_csv,$name"
           fi
         done
 
-        TENANT=$(fetch_secret_value "$TENANT_UUID")
-        CLIENT_ID=$(fetch_secret_value "$CLIENT_ID_UUID")
-        CLIENT_SECRET=$(fetch_secret_value "$CLIENT_SECRET_UUID")
-        GRAPH_SENDER=$(fetch_secret_value "$GRAPH_SENDER_UUID")
-        SLACK_WEBHOOK=$(fetch_secret_value "$SLACK_WEBHOOK_UUID")
-
-        for required_value in "$TENANT" "$CLIENT_ID" "$CLIENT_SECRET" "$GRAPH_SENDER" "$SLACK_WEBHOOK"; do
-          if [ -z "$required_value" ]; then
-            echo "✗ Mindestens ein erforderlicher BSM-Wert ist leer"
-            exit 1
-          fi
-        done
-
-        [ -n "${TENANT:-}" ] && echo "::add-mask::${TENANT}"
-        [ -n "${CLIENT_ID:-}" ] && echo "::add-mask::${CLIENT_ID}"
-        [ -n "${CLIENT_SECRET:-}" ] && echo "::add-mask::${CLIENT_SECRET}"
-        [ -n "${GRAPH_SENDER:-}" ] && echo "::add-mask::${GRAPH_SENDER}"
-        [ -n "${SLACK_WEBHOOK:-}" ] && echo "::add-mask::${SLACK_WEBHOOK}"
-
-        {
-          printf 'MICROSOFT_TENANT_ID=%s\n' "$TENANT"
-          printf 'MICROSOFT_CLIENT_ID=%s\n' "$CLIENT_ID"
-          printf 'MICROSOFT_CLIENT_SECRET=%s\n' "$CLIENT_SECRET"
-          printf 'MICROSOFT_GRAPH_SENDER=%s\n' "$GRAPH_SENDER"
-          printf 'ALERTS_SLACK_WEBHOOK=%s\n' "$SLACK_WEBHOOK"
-        } >> "$GITHUB_ENV"
-
-        echo "injected=${BSM_PROFILE}" >> "$GITHUB_OUTPUT"
+        echo "injected=${injected_csv}" >> "$GITHUB_OUTPUT"
 
         echo "### 🔐 BSM Secret Injection" >> "$GITHUB_STEP_SUMMARY"
         echo "- **Profil:** \`${BSM_PROFILE}\`" >> "$GITHUB_STEP_SUMMARY"
         echo "- **Quelle:** Bitwarden Secrets Manager (bws + UUID-Mapping)" >> "$GITHUB_STEP_SUMMARY"
         echo "- **Handoff:** ueber GITHUB_ENV im aktuellen Job" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Geladene Keys:** ${injected_csv}" >> "$GITHUB_STEP_SUMMARY"
         echo "- **Status:** ✅ Erfolgreich" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/bsm-secret-ids.json
+++ b/.github/bsm-secret-ids.json
@@ -55,6 +55,42 @@
           "uuid": "4b4511f7-1660-43f7-b3ff-b4190148d68d"
         },
         {
+          "bsm_key": "api/JWT_SECRET_KEY",
+          "env_var": "JWT_SECRET_KEY",
+          "github_variable": "BSM_API_JWT_SECRET_KEY",
+          "uuid": "eb662caa-141c-4a97-8e56-b4190148d80f"
+        },
+        {
+          "bsm_key": "api/STRIPE_SECRET_KEY",
+          "env_var": "STRIPE_SECRET_KEY",
+          "github_variable": "BSM_API_STRIPE_SECRET_KEY",
+          "uuid": "3ee3dcf1-f25a-4497-9f8b-b4360118ba37"
+        },
+        {
+          "bsm_key": "api/STRIPE_WEBHOOK_SECRET",
+          "env_var": "STRIPE_WEBHOOK_SECRET",
+          "github_variable": "BSM_API_STRIPE_WEBHOOK_SECRET",
+          "uuid": "f4533ec6-adfc-4033-905a-b4360118ba7a"
+        },
+        {
+          "bsm_key": "api/CIVICRM_SITE_KEY",
+          "env_var": "CIVICRM_SITE_KEY",
+          "github_variable": "BSM_API_CIVICRM_SITE_KEY",
+          "uuid": "0aced3bc-8bd1-474f-9a19-b4190148d6f7"
+        },
+        {
+          "bsm_key": "api/CIVICRM_API_KEY",
+          "env_var": "CIVICRM_API_KEY",
+          "github_variable": "BSM_API_CIVICRM_API_KEY",
+          "uuid": "4a328505-3e0b-4c4c-b5e8-b4190148d790"
+        },
+        {
+          "bsm_key": "api/N8N_WEBHOOK_SECRET",
+          "env_var": "N8N_WEBHOOK_SECRET",
+          "github_variable": "BSM_API_N8N_WEBHOOK_SECRET",
+          "uuid": "2079480f-d4a9-4676-9a66-b4190148d87f"
+        },
+        {
           "bsm_key": "api/ALERTS_SLACK_WEBHOOK",
           "env_var": "ALERTS_SLACK_WEBHOOK",
           "github_variable": "BSM_API_ALERTS_SLACK_WEBHOOK",
@@ -127,28 +163,10 @@
       "service_account": "sa-api-dev",
       "secrets": [
         {
-          "bsm_key": "api/CIVICRM_SITE_KEY",
-          "env_var": "CIVICRM_SITE_KEY",
-          "github_variable": "BSM_API_CIVICRM_SITE_KEY",
-          "uuid": "0aced3bc-8bd1-474f-9a19-b4190148d6f7"
-        },
-        {
-          "bsm_key": "api/CIVICRM_API_KEY",
-          "env_var": "CIVICRM_API_KEY",
-          "github_variable": "BSM_API_CIVICRM_API_KEY",
-          "uuid": "4a328505-3e0b-4c4c-b5e8-b4190148d790"
-        },
-        {
           "bsm_key": "api/JWT_SECRET_KEY",
           "env_var": "JWT_SECRET_KEY",
           "github_variable": "BSM_API_JWT_SECRET_KEY",
           "uuid": "eb662caa-141c-4a97-8e56-b4190148d80f"
-        },
-        {
-          "bsm_key": "api/N8N_WEBHOOK_SECRET",
-          "env_var": "N8N_WEBHOOK_SECRET",
-          "github_variable": "BSM_API_N8N_WEBHOOK_SECRET",
-          "uuid": "2079480f-d4a9-4676-9a66-b4190148d87f"
         }
       ]
     },

--- a/.github/workflows/deploy-plesk.yml
+++ b/.github/workflows/deploy-plesk.yml
@@ -256,19 +256,34 @@ jobs:
       - name: Preflight → BSM Secret Validation
         run: |
           set -euo pipefail
-          TENANT="${MICROSOFT_TENANT_ID:-}"
-          CLIENT="${MICROSOFT_CLIENT_ID:-}"
-          SECRET="${MICROSOFT_CLIENT_SECRET:-}"
-          SENDER="${MICROSOFT_GRAPH_SENDER:-}"
-          WEBHOOK="${ALERTS_SLACK_WEBHOOK:-}"
-
           echo "=== Preflight: BSM Secret Validation ==="
           ERRORS=0
-          [ -n "${TENANT}" ] && echo "✓ MICROSOFT_TENANT_ID" || { echo "✗ MICROSOFT_TENANT_ID fehlt"; ERRORS=$((ERRORS+1)); }
-          [ -n "${CLIENT}" ] && echo "✓ MICROSOFT_CLIENT_ID" || { echo "✗ MICROSOFT_CLIENT_ID fehlt"; ERRORS=$((ERRORS+1)); }
-          [ -n "${SECRET}" ] && echo "✓ MICROSOFT_CLIENT_SECRET" || { echo "✗ MICROSOFT_CLIENT_SECRET fehlt"; ERRORS=$((ERRORS+1)); }
-          [ -n "${SENDER}" ] && echo "✓ MICROSOFT_GRAPH_SENDER" || { echo "✗ MICROSOFT_GRAPH_SENDER fehlt"; ERRORS=$((ERRORS+1)); }
-          [ -n "${WEBHOOK}" ] && echo "✓ ALERTS_SLACK_WEBHOOK" || { echo "✗ ALERTS_SLACK_WEBHOOK fehlt"; ERRORS=$((ERRORS+1)); }
+
+          required_keys=(
+            DATABASE_URL
+            JWT_SECRET_KEY
+            STRIPE_SECRET_KEY
+            STRIPE_WEBHOOK_SECRET
+            MOE_API_TOKEN
+            N8N_WEBHOOK_SECRET
+            CIVICRM_SITE_KEY
+            CIVICRM_API_KEY
+            ALERTS_SLACK_WEBHOOK
+            MICROSOFT_TENANT_ID
+            MICROSOFT_CLIENT_ID
+            MICROSOFT_CLIENT_SECRET
+            MICROSOFT_GRAPH_SENDER
+          )
+
+          for key in "${required_keys[@]}"; do
+            value="${!key:-}"
+            if [ -n "$value" ]; then
+              echo "✓ ${key}"
+            else
+              echo "✗ ${key} fehlt"
+              ERRORS=$((ERRORS+1))
+            fi
+          done
 
           if [ "${ERRORS}" -gt 0 ]; then
             echo "✗ ${ERRORS} BSM-Secret(s) fehlen. Deployment abgebrochen."
@@ -533,19 +548,34 @@ jobs:
           env.TARGET_SERVICE == 'api'
         run: |
           set -euo pipefail
-          TENANT="${MICROSOFT_TENANT_ID:-}"
-          CLIENT="${MICROSOFT_CLIENT_ID:-}"
-          SECRET="${MICROSOFT_CLIENT_SECRET:-}"
-          SENDER="${MICROSOFT_GRAPH_SENDER:-}"
-          WEBHOOK="${ALERTS_SLACK_WEBHOOK:-}"
-
           echo "=== Preflight: BSM Secret Validation ==="
           ERRORS=0
-          [ -n "${TENANT}" ] && echo "✓ MICROSOFT_TENANT_ID" || { echo "✗ MICROSOFT_TENANT_ID fehlt"; ERRORS=$((ERRORS+1)); }
-          [ -n "${CLIENT}" ] && echo "✓ MICROSOFT_CLIENT_ID" || { echo "✗ MICROSOFT_CLIENT_ID fehlt"; ERRORS=$((ERRORS+1)); }
-          [ -n "${SECRET}" ] && echo "✓ MICROSOFT_CLIENT_SECRET" || { echo "✗ MICROSOFT_CLIENT_SECRET fehlt"; ERRORS=$((ERRORS+1)); }
-          [ -n "${SENDER}" ] && echo "✓ MICROSOFT_GRAPH_SENDER" || { echo "✗ MICROSOFT_GRAPH_SENDER fehlt"; ERRORS=$((ERRORS+1)); }
-          [ -n "${WEBHOOK}" ] && echo "✓ ALERTS_SLACK_WEBHOOK" || { echo "✗ ALERTS_SLACK_WEBHOOK fehlt"; ERRORS=$((ERRORS+1)); }
+
+          required_keys=(
+            DATABASE_URL
+            JWT_SECRET_KEY
+            STRIPE_SECRET_KEY
+            STRIPE_WEBHOOK_SECRET
+            MOE_API_TOKEN
+            N8N_WEBHOOK_SECRET
+            CIVICRM_SITE_KEY
+            CIVICRM_API_KEY
+            ALERTS_SLACK_WEBHOOK
+            MICROSOFT_TENANT_ID
+            MICROSOFT_CLIENT_ID
+            MICROSOFT_CLIENT_SECRET
+            MICROSOFT_GRAPH_SENDER
+          )
+
+          for key in "${required_keys[@]}"; do
+            value="${!key:-}"
+            if [ -n "$value" ]; then
+              echo "✓ ${key}"
+            else
+              echo "✗ ${key} fehlt"
+              ERRORS=$((ERRORS+1))
+            fi
+          done
 
           if [ "${ERRORS}" -gt 0 ]; then
             echo "✗ ${ERRORS} BSM-Secret(s) fehlen. Deployment abgebrochen."
@@ -557,19 +587,25 @@ jobs:
         if: >
           env.TARGET_SERVICE == 'all' ||
           env.TARGET_SERVICE == 'api'
-        env:
-          MAIL_TRANSPORT_SECRET: ${{ secrets.MAIL_TRANSPORT }}
         run: |
           set -euo pipefail
-          echo "=== API Deploy: Graph/Slack Secrets aus aktueller Job-Umgebung ==="
+          echo "=== API Deploy: Vollständiger Secret-Handoff aus aktueller Job-Umgebung ==="
 
           {
-            printf 'MAIL_TRANSPORT=%s\n' "${MAIL_TRANSPORT_SECRET:-graph}"
+            printf 'MAIL_TRANSPORT=%s\n' "graph"
+            printf 'DATABASE_URL=%s\n' "${DATABASE_URL}"
+            printf 'JWT_SECRET_KEY=%s\n' "${JWT_SECRET_KEY}"
+            printf 'STRIPE_SECRET_KEY=%s\n' "${STRIPE_SECRET_KEY}"
+            printf 'STRIPE_WEBHOOK_SECRET=%s\n' "${STRIPE_WEBHOOK_SECRET}"
+            printf 'MOE_API_TOKEN=%s\n' "${MOE_API_TOKEN}"
+            printf 'N8N_WEBHOOK_SECRET=%s\n' "${N8N_WEBHOOK_SECRET}"
+            printf 'CIVICRM_SITE_KEY=%s\n' "${CIVICRM_SITE_KEY}"
+            printf 'CIVICRM_API_KEY=%s\n' "${CIVICRM_API_KEY}"
             printf 'MICROSOFT_TENANT_ID=%s\n' "${MICROSOFT_TENANT_ID}"
             printf 'MICROSOFT_CLIENT_ID=%s\n' "${MICROSOFT_CLIENT_ID}"
             printf 'MICROSOFT_CLIENT_SECRET=%s\n' "${MICROSOFT_CLIENT_SECRET}"
             printf 'MICROSOFT_GRAPH_SENDER=%s\n' "${MICROSOFT_GRAPH_SENDER}"
-            printf 'ALERTS_SLACK_WEBHOOK=%s\n' "${ALERTS_SLACK_WEBHOOK:-}"
+            printf 'ALERTS_SLACK_WEBHOOK=%s\n' "${ALERTS_SLACK_WEBHOOK}"
           } > /tmp/api-runtime.env
 
           # Pfad relativ zum Chroot-Home
@@ -586,7 +622,7 @@ jobs:
             OVERLAY_FILE='${{ env.API_REMOTE_PATH }}/.env.deploy'
             TMP_FILE='${{ env.API_REMOTE_PATH }}/.env.merged'
             if [ -f \"\$ENV_FILE\" ]; then
-              grep -vE '^(MAIL_TRANSPORT|MICROSOFT_TENANT_ID|MICROSOFT_CLIENT_ID|MICROSOFT_CLIENT_SECRET|MICROSOFT_GRAPH_SENDER|ALERTS_SLACK_WEBHOOK)=' \"\$ENV_FILE\" > \"\$TMP_FILE\" || true
+              grep -vE '^(MAIL_TRANSPORT|DATABASE_URL|JWT_SECRET_KEY|STRIPE_SECRET_KEY|STRIPE_WEBHOOK_SECRET|MOE_API_TOKEN|N8N_WEBHOOK_SECRET|CIVICRM_SITE_KEY|CIVICRM_API_KEY|MICROSOFT_TENANT_ID|MICROSOFT_CLIENT_ID|MICROSOFT_CLIENT_SECRET|MICROSOFT_GRAPH_SENDER|ALERTS_SLACK_WEBHOOK)=' "\$ENV_FILE" > "\$TMP_FILE" || true
               cat \"\$OVERLAY_FILE\" >> \"\$TMP_FILE\"
               mv \"\$TMP_FILE\" \"\$ENV_FILE\"
               rm -f \"\$OVERLAY_FILE\"

--- a/.github/workflows/reusable-bsm-secrets.yml
+++ b/.github/workflows/reusable-bsm-secrets.yml
@@ -51,6 +51,30 @@ on:
       ALERTS_SLACK_WEBHOOK:
         description: 'Slack Webhook für Deployment-Alerts'
         value: ${{ jobs.inject.outputs.ALERTS_SLACK_WEBHOOK }}
+      DATABASE_URL:
+        description: 'Primäre API-Datenbankverbindung'
+        value: ${{ jobs.inject.outputs.DATABASE_URL }}
+      JWT_SECRET_KEY:
+        description: 'JWT Signing Key für API Auth'
+        value: ${{ jobs.inject.outputs.JWT_SECRET_KEY }}
+      STRIPE_SECRET_KEY:
+        description: 'Stripe Secret für Payment-API'
+        value: ${{ jobs.inject.outputs.STRIPE_SECRET_KEY }}
+      STRIPE_WEBHOOK_SECRET:
+        description: 'Stripe Webhook Secret für Signaturprüfung'
+        value: ${{ jobs.inject.outputs.STRIPE_WEBHOOK_SECRET }}
+      MOE_API_TOKEN:
+        description: 'Interner API-Token für systeminterne Integrationen'
+        value: ${{ jobs.inject.outputs.MOE_API_TOKEN }}
+      N8N_WEBHOOK_SECRET:
+        description: 'Webhook Shared Secret für n8n-Aufrufe'
+        value: ${{ jobs.inject.outputs.N8N_WEBHOOK_SECRET }}
+      CIVICRM_SITE_KEY:
+        description: 'CiviCRM Site Key'
+        value: ${{ jobs.inject.outputs.CIVICRM_SITE_KEY }}
+      CIVICRM_API_KEY:
+        description: 'CiviCRM API Key'
+        value: ${{ jobs.inject.outputs.CIVICRM_API_KEY }}
 
 permissions:
   contents: read
@@ -66,6 +90,14 @@ jobs:
       MICROSOFT_CLIENT_SECRET: ${{ steps.inject-secrets.outputs.MICROSOFT_CLIENT_SECRET }}
       MICROSOFT_GRAPH_SENDER: ${{ steps.inject-secrets.outputs.MICROSOFT_GRAPH_SENDER }}
       ALERTS_SLACK_WEBHOOK: ${{ steps.inject-secrets.outputs.ALERTS_SLACK_WEBHOOK }}
+      DATABASE_URL: ${{ steps.inject-secrets.outputs.DATABASE_URL }}
+      JWT_SECRET_KEY: ${{ steps.inject-secrets.outputs.JWT_SECRET_KEY }}
+      STRIPE_SECRET_KEY: ${{ steps.inject-secrets.outputs.STRIPE_SECRET_KEY }}
+      STRIPE_WEBHOOK_SECRET: ${{ steps.inject-secrets.outputs.STRIPE_WEBHOOK_SECRET }}
+      MOE_API_TOKEN: ${{ steps.inject-secrets.outputs.MOE_API_TOKEN }}
+      N8N_WEBHOOK_SECRET: ${{ steps.inject-secrets.outputs.N8N_WEBHOOK_SECRET }}
+      CIVICRM_SITE_KEY: ${{ steps.inject-secrets.outputs.CIVICRM_SITE_KEY }}
+      CIVICRM_API_KEY: ${{ steps.inject-secrets.outputs.CIVICRM_API_KEY }}
 
     steps:
       - name: Checkout (BSM-Mapping laden)
@@ -92,6 +124,11 @@ jobs:
 
           if ! command -v jq >/dev/null 2>&1; then
             echo "✗ jq fehlt auf Runner"
+            exit 1
+          fi
+
+          if [ "$(jq -r --arg profile "$BSM_PROFILE" 'has("profiles") and (.profiles | has($profile))' "$MAP_FILE")" != "true" ]; then
+            echo "✗ Profil '$BSM_PROFILE' fehlt in $MAP_FILE"
             exit 1
           fi
 
@@ -124,57 +161,101 @@ jobs:
             printf '%s' "$value"
           }
 
-          resolve_uuid() {
-            local env_var="$1"
-            jq -r --arg profile "$BSM_PROFILE" --arg env_var "$env_var" '
-              .profiles[$profile].secrets[]?
-              | select(.env_var == $env_var)
-              | .uuid
-            ' "$MAP_FILE" | head -n1
+          write_multiline() {
+            local key="$1"
+            local value="$2"
+            local target_file="$3"
+            local delim="EOF_$(date +%s)_$RANDOM"
+            {
+              printf '%s<<%s\n' "$key" "$delim"
+              printf '%s\n' "$value"
+              printf '%s\n' "$delim"
+            } >> "$target_file"
           }
 
-          TENANT_UUID=$(resolve_uuid "MICROSOFT_TENANT_ID")
-          CLIENT_ID_UUID=$(resolve_uuid "MICROSOFT_CLIENT_ID")
-          CLIENT_SECRET_UUID=$(resolve_uuid "MICROSOFT_CLIENT_SECRET")
-          GRAPH_SENDER_UUID=$(resolve_uuid "MICROSOFT_GRAPH_SENDER")
-          SLACK_WEBHOOK_UUID=$(resolve_uuid "ALERTS_SLACK_WEBHOOK")
+          mapfile -t secret_rows < <(jq -r --arg profile "$BSM_PROFILE" '.profiles[$profile].secrets[]? | @base64' "$MAP_FILE")
 
-          for required_uuid in "$TENANT_UUID" "$CLIENT_ID_UUID" "$CLIENT_SECRET_UUID" "$GRAPH_SENDER_UUID" "$SLACK_WEBHOOK_UUID"; do
-            if [ -z "$required_uuid" ] || [ "$required_uuid" = "null" ]; then
-              echo "✗ Unvollstaendiges Mapping fuer Profil '$BSM_PROFILE'"
+          if [ "${#secret_rows[@]}" -eq 0 ]; then
+            echo "✗ Profil '$BSM_PROFILE' enthält keine Secrets"
+            exit 1
+          fi
+
+          declare -A loaded_keys=()
+          injected_names=()
+
+          for row in "${secret_rows[@]}"; do
+            entry_json=$(printf '%s' "$row" | base64 --decode)
+            env_var=$(printf '%s' "$entry_json" | jq -r '.env_var // empty')
+            uuid=$(printf '%s' "$entry_json" | jq -r '.uuid // empty')
+
+            if [ -z "$env_var" ]; then
+              echo "✗ Profil '$BSM_PROFILE' enthält Secret ohne env_var"
               exit 1
+            fi
+
+            if [ -z "$uuid" ] || [ "$uuid" = "null" ]; then
+              echo "✗ Secret '$env_var' hat keine UUID im Profil '$BSM_PROFILE'"
+              exit 1
+            fi
+
+            if [[ "$uuid" == "UPDATE_VALUE_IN_VAULT" || "$uuid" == PLACEHOLDER_* ]]; then
+              echo "✗ Secret '$env_var' hat Platzhalter-UUID im Profil '$BSM_PROFILE'"
+              exit 1
+            fi
+
+            value=$(fetch_secret_value "$uuid")
+            if [ -z "$value" ]; then
+              echo "✗ Secret '$env_var' ist leer im Profil '$BSM_PROFILE'"
+              exit 1
+            fi
+
+            echo "::add-mask::${value}"
+            write_multiline "$env_var" "$value" "$GITHUB_OUTPUT"
+            loaded_keys["$env_var"]=1
+            injected_names+=("$env_var")
+          done
+
+          if [ "$BSM_PROFILE" = "deploy-production" ]; then
+            required_keys=(
+              DATABASE_URL
+              JWT_SECRET_KEY
+              STRIPE_SECRET_KEY
+              STRIPE_WEBHOOK_SECRET
+              MOE_API_TOKEN
+              N8N_WEBHOOK_SECRET
+              CIVICRM_SITE_KEY
+              CIVICRM_API_KEY
+              ALERTS_SLACK_WEBHOOK
+              MICROSOFT_TENANT_ID
+              MICROSOFT_CLIENT_ID
+              MICROSOFT_CLIENT_SECRET
+              MICROSOFT_GRAPH_SENDER
+            )
+
+            for required_key in "${required_keys[@]}"; do
+              if [ -z "${loaded_keys[$required_key]+x}" ]; then
+                echo "✗ Pflicht-Secret '$required_key' fehlt im Profil '$BSM_PROFILE'"
+                exit 1
+              fi
+            done
+          fi
+
+          injected_csv=""
+          for name in "${injected_names[@]}"; do
+            if [ -z "$injected_csv" ]; then
+              injected_csv="$name"
+            else
+              injected_csv="$injected_csv,$name"
             fi
           done
 
-          TENANT=$(fetch_secret_value "$TENANT_UUID")
-          CLIENT_ID=$(fetch_secret_value "$CLIENT_ID_UUID")
-          CLIENT_SECRET=$(fetch_secret_value "$CLIENT_SECRET_UUID")
-          GRAPH_SENDER=$(fetch_secret_value "$GRAPH_SENDER_UUID")
-          SLACK_WEBHOOK=$(fetch_secret_value "$SLACK_WEBHOOK_UUID")
-
-          for required_value in "$TENANT" "$CLIENT_ID" "$CLIENT_SECRET" "$GRAPH_SENDER" "$SLACK_WEBHOOK"; do
-            if [ -z "$required_value" ]; then
-              echo "✗ Mindestens ein erforderlicher BSM-Wert ist leer"
-              exit 1
-            fi
-          done
-
-          [ -n "${TENANT:-}" ] && echo "::add-mask::${TENANT}"
-          [ -n "${CLIENT_ID:-}" ] && echo "::add-mask::${CLIENT_ID}"
-          [ -n "${CLIENT_SECRET:-}" ] && echo "::add-mask::${CLIENT_SECRET}"
-          [ -n "${GRAPH_SENDER:-}" ] && echo "::add-mask::${GRAPH_SENDER}"
-          [ -n "${SLACK_WEBHOOK:-}" ] && echo "::add-mask::${SLACK_WEBHOOK}"
-
-          echo "MICROSOFT_TENANT_ID=${TENANT}" >> "$GITHUB_OUTPUT"
-          echo "MICROSOFT_CLIENT_ID=${CLIENT_ID}" >> "$GITHUB_OUTPUT"
-          echo "MICROSOFT_CLIENT_SECRET=${CLIENT_SECRET}" >> "$GITHUB_OUTPUT"
-          echo "MICROSOFT_GRAPH_SENDER=${GRAPH_SENDER}" >> "$GITHUB_OUTPUT"
-          echo "ALERTS_SLACK_WEBHOOK=${SLACK_WEBHOOK}" >> "$GITHUB_OUTPUT"
-          echo "injected=${{ inputs.profile }}" >> "$GITHUB_OUTPUT"
+          echo "injected=${injected_csv}" >> "$GITHUB_OUTPUT"
+          echo "injected_keys=${injected_csv}" >> "$GITHUB_OUTPUT"
 
           echo "✅ Profil '${{ inputs.profile }}' verarbeitet"
           echo "### 🔐 BSM Secret Injection" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Profil:** \`${{ inputs.profile }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Quelle:** Bitwarden Secrets Manager (bws + UUID-Mapping)" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Handoff:** über reusable workflow outputs" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Geladene Keys:** ${injected_csv}" >> "$GITHUB_STEP_SUMMARY"
           echo "- **Status:** ✅ Erfolgreich" >> "$GITHUB_STEP_SUMMARY"

--- a/SECRETS-QUICK-START.md
+++ b/SECRETS-QUICK-START.md
@@ -76,7 +76,7 @@ DATABASE_URL=postgresql://postgres:STRONG_PASSWORD_HERE@localhost:5432/menschlic
 # Migrations ausführen
 npx prisma generate
 npx prisma migrate dev
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 alembic upgrade head
 ```
 
@@ -113,10 +113,10 @@ start https://github.com/settings/tokens/new
 # 3. "Generate token" klicken → Token kopieren (ghp_...)
 
 # 4. .env aktualisieren
-GH_TOKEN=ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+GH_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # 5. GitHub Secret setzen:
-start https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/settings/secrets/actions/new
+start https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/settings/secrets/actions/new
 # Name: GH_TOKEN
 # Secret: ghp_XXX... (aus Schritt 3)
 ```

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -24,8 +24,8 @@ This document provides guidance on how to get support for this project.
 
 1. **Search existing resources:**
    - Check the [Documentation](docs/)
-   - Search [existing Issues](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/issues)
-   - Review [Discussions](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions)
+   - Search [existing Issues](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/issues)
+   - Review [Discussions](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions)
 
 2. **Try debugging:**
    - Enable debug mode: `DEBUG=* npm run dev`
@@ -33,13 +33,14 @@ This document provides guidance on how to get support for this project.
    - Run diagnostics: `npm run quality:gates`
 
 3. **Verify your setup:**
+
    ```bash
    # Check Node.js version
    node --version  # Should be >= 22.0.0
-   
+
    # Check npm version
    npm --version   # Should be >= 10.0.0
-   
+
    # Verify installation
    npm run verify
    ```
@@ -50,9 +51,9 @@ This document provides guidance on how to get support for this project.
 
 For questions, ideas, and general discussion:
 
-- **[Q&A](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions/categories/q-a)** - Ask questions
-- **[Ideas](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions/categories/ideas)** - Suggest improvements
-- **[Show and Tell](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions/categories/show-and-tell)** - Share what you've built
+- **[Q&A](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions/categories/q-a)** - Ask questions
+- **[Ideas](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions/categories/ideas)** - Suggest improvements
+- **[Show and Tell](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions/categories/show-and-tell)** - Share what you've built
 
 #### 🐛 GitHub Issues
 
@@ -98,6 +99,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '...'
 3. See error
@@ -106,9 +108,10 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Environment:**
- - OS: [e.g., macOS 14.1]
- - Node: [e.g., 22.0.0]
- - Browser: [e.g., Chrome 120]
+
+- OS: [e.g., macOS 14.1]
+- Node: [e.g., 22.0.0]
+- Browser: [e.g., Chrome 120]
 
 **Additional context**
 Add any other context about the problem here.
@@ -142,7 +145,7 @@ Please see our [Security Policy](SECURITY.md) for instructions on reporting secu
 - **[README](README.md)** - Project overview and quick start
 - **[Contributing Guide](CONTRIBUTING.md)** - How to contribute
 - **[Architecture Docs](docs/architecture/)** - System architecture
-- **[API Documentation](api.menschlichkeit-oesterreich.at/docs)** - API reference
+- **[API Specification](apps/api/openapi.yaml)** - Source-of-truth API reference for local development
 - **[Deployment Guide](deployment-scripts/README.md)** - Deployment instructions
 
 ### Tutorials & Guides
@@ -186,8 +189,9 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md).
 A: A comprehensive digital platform for democratic participation, education, and community engagement in Austria.
 
 **Q: What technologies does this project use?**  
-A: 
-- **Frontend:** React 18, TypeScript, Tailwind CSS
+A:
+
+- **Frontend:** React 19, TypeScript, Tailwind CSS
 - **Backend:** FastAPI (Python), Node.js
 - **CRM:** Drupal 10 + CiviCRM
 - **Database:** PostgreSQL 16, MariaDB
@@ -203,6 +207,7 @@ A: Use Node.js 22.x LTS or higher. We recommend using [nvm](https://github.com/n
 
 **Q: How do I run the project locally?**  
 A:
+
 ```bash
 npm install
 npm run dev:all
@@ -210,6 +215,7 @@ npm run dev:all
 
 **Q: How do I run tests?**  
 A:
+
 ```bash
 # Unit tests
 npm run test:unit
@@ -223,6 +229,7 @@ npm run test
 
 **Q: How do I check code quality?**  
 A:
+
 ```bash
 npm run quality:gates
 ```
@@ -231,6 +238,7 @@ npm run quality:gates
 
 **Q: How do I deploy to staging?**  
 A:
+
 ```bash
 ./build-pipeline.sh staging
 ```
@@ -240,6 +248,7 @@ A: See the [Deployment Guide](deployment-scripts/README.md) for detailed instruc
 
 **Q: How do I rollback a deployment?**  
 A:
+
 ```bash
 npm run deploy:rollback
 ```
@@ -259,6 +268,7 @@ A: See [Right to Erasure Procedures](docs/compliance/RIGHT-TO-ERASURE-PROCEDURES
 
 **Q: I'm getting "Cannot find module" errors**  
 A: Try:
+
 ```bash
 rm -rf node_modules package-lock.json
 npm install
@@ -266,12 +276,14 @@ npm install
 
 **Q: The development server won't start**  
 A: Check:
+
 1. Is port 3000 already in use?
 2. Are all dependencies installed?
 3. Is your `.env` file configured correctly?
 
 **Q: Tests are failing**  
 A: Try:
+
 ```bash
 npm run test:clean
 npm run test
@@ -279,6 +291,7 @@ npm run test
 
 **Q: Build is failing**  
 A: Try:
+
 ```bash
 npm run clean
 npm run build
@@ -297,9 +310,9 @@ npm run build
 
 ### GitHub
 
-- **Issues:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/issues](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/issues)
-- **Discussions:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions)
-- **Pull Requests:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/pulls](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/pulls)
+- **Issues:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/issues](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/issues)
+- **Discussions:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions)
+- **Pull Requests:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/pulls](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/pulls)
 
 ### Response Times
 
@@ -313,7 +326,7 @@ npm run build
 For complex issues, we offer virtual office hours:
 
 - **When:** Every Friday, 14:00-16:00 CET/CEST
-- **Where:** [GitHub Discussions - Office Hours](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions/categories/office-hours)
+- **Where:** [GitHub Discussions - Office Hours](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions/categories/office-hours)
 - **How:** Post your question beforehand, join the discussion on Friday
 
 ---

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -234,6 +234,8 @@ On Release:
 
 ### Domain Structure
 
+Hinweis: Die folgende Liste beschreibt Laufzeit-Domains in Produktion und Staging. Aktive Entwicklungs- und Source-Pfade im Repository liegen unter `apps/` und `automation/`, insbesondere `apps/website/`, `apps/api/`, `apps/crm/`, `apps/babylon-game/` und `automation/n8n/`.
+
 ```
 menschlichkeit-oesterreich.at/
 ├── www.menschlichkeit-oesterreich.at (Website)

--- a/runbooks/service-restart.md
+++ b/runbooks/service-restart.md
@@ -40,6 +40,8 @@ npm run status:check
 
 ## 2. FastAPI (API Service)
 
+Hinweis: Die Abschnitte unter "Lokal" beschreiben Repository-Pfade und Dev-Kommandos. Die Abschnitte unter "Produktion (Plesk)" beschreiben ausschliesslich Laufzeitpfade auf dem Server und sind keine lokalen Arbeitsverzeichnisse.
+
 ### Lokal (Entwicklung)
 
 ```bash
@@ -90,6 +92,8 @@ npm run build:frontend
 ---
 
 ## 4. CRM (Drupal + CiviCRM)
+
+Hinweis: `crm.menschlichkeit-oesterreich.at` ist hier ein Plesk-Domain-Kontext. Fuer lokale Entwicklung im Repository gilt weiterhin der Source-Pfad `apps/crm/`.
 
 ### Lokal
 


### PR DESCRIPTION
Ziel:
- reine doku-scope-haertung fuer aktive versus legacy-/mirror-pfade, ohne runtime-aenderung

Umfang:
- nur die sechs vereinbarten doku-dateien
- keine produktlogik, keine workflows, keine secret-/deploy-/mail-/slack-logik

Kernanpassungen:
- aktive lokale pfade konsistent auf die apps-struktur gefuehrt, inklusive apps/babylon-game
- legacy-/mirror-/domainpfade nicht mehr als gleichrangige lokale entwicklungsziele formuliert
- klare trennung von lokalem source-scope und produktions-/plesk-laufzeitkontext
- repository-links auf das korrekte github-repo vereinheitlicht

Betroffene Dateien:
- .devcontainer/README.md
- .devcontainer/TROUBLESHOOTING.md
- SUPPORT.md
- SECRETS-QUICK-START.md
- runbooks/service-restart.md
- docs/wiki/Architecture.md

Validierung:
- scope-diff ist auf diese sechs dateien begrenzt
- aenderungen sind rein dokumentationsbasiert