### PR TITLE
docs(scope): aktive source-pfade klarstellen und runtime-kontext abgrenzen

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -93,7 +93,7 @@ cat .devcontainer/TROUBLESHOOTING.md
 If the API service fails to start due to missing dependencies:
 
 ```bash
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 # With timeout protection (recommended)
 timeout 120 pip install --user fastapi uvicorn python-dotenv
 # OR for full requirements:
@@ -119,7 +119,7 @@ pwsh .devcontainer/setup-powershell.ps1
 If pip installation times out during setup:
 
 ```bash
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 # The setup script now uses timeout automatically
 timeout 300 pip install --user --timeout 300 -r requirements.txt
 # OR install essentials only:
@@ -130,9 +130,9 @@ pip install --user -r requirements-minimal.txt
 
 The setup automatically creates `.env` files from examples. To customize:
 
-1. **API Configuration**: Edit `api.menschlichkeit-oesterreich.at/.env`
-2. **Frontend Configuration**: Edit `frontend/.env`
-3. **CRM Configuration**: Edit `crm.menschlichkeit-oesterreich.at/.env`
+1. **API Configuration**: Edit `apps/api/.env`
+2. **Website Configuration**: Edit `apps/website/.env.local`
+3. **CRM Configuration**: Review the Drupal/CiviCRM settings under `apps/crm/`
 
 ## 📊 Quality & Testing
 
@@ -194,9 +194,11 @@ For more help, see:
 
 ## 📁 Project Structure
 
-- `frontend/` - React/TypeScript frontend
-- `api.menschlichkeit-oesterreich.at/` - FastAPI Python backend
-- `crm.menschlichkeit-oesterreich.at/` - CiviCRM PHP application
-- `web/` - Educational games
+- `apps/website/` - React/TypeScript frontend
+- `apps/api/` - FastAPI Python backend
+- `apps/crm/` - Drupal 10 + CiviCRM
+- `apps/babylon-game/` - Educational games
 - `automation/n8n/` - Workflow automation
 - `scripts/` - Development and deployment scripts
+
+Hinweis: Domain- oder Mirror-Pfade wie `api.menschlichkeit-oesterreich.at/` und `crm.menschlichkeit-oesterreich.at/` sind keine aktiven lokalen Entwicklungsziele in diesem Repository.

--- a/.devcontainer/TROUBLESHOOTING.md
+++ b/.devcontainer/TROUBLESHOOTING.md
@@ -5,6 +5,7 @@
 ### Problem: Devcontainer startet nicht oder hängt
 
 **Symptome:**
+
 - Codespace öffnet sich nicht vollständig
 - Setup-Prozess bleibt hängen
 - Fehlermeldungen beim Start
@@ -12,15 +13,17 @@
 **Lösung:**
 
 1. **Diagnose ausführen**
+
    ```bash
    bash .devcontainer/diagnose.sh
    ```
 
 2. **Logs überprüfen**
+
    ```bash
    # onCreate Log (falls vorhanden)
    cat /tmp/devcontainer-onCreate-setup.log
-   
+
    # Setup-Test ausführen
    bash .devcontainer/test-setup.sh
    ```
@@ -33,11 +36,13 @@
 ### Problem: Keine Netzwerkverbindung (Offline-Modus)
 
 **Symptome:**
+
 - `Network connectivity failed` Meldungen
 - npm/pip Installation schlägt fehl
 - Git clone/push funktioniert nicht
 
 **Erklärung:**
+
 - Dies ist normal in CI/Test-Umgebungen ohne Internet
 - Setup-Scripts erkennen dies automatisch und arbeiten offline
 
@@ -50,17 +55,18 @@
 # npm Pakete nachinstallieren
 npm install
 
-# Python Pakete nachinstallieren  
+# Python Pakete nachinstallieren
 pip install --user fastapi uvicorn python-dotenv pydantic
 
 # Vollständige API Requirements
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 pip install --user -r app/requirements.txt
 ```
 
 ### Problem: Python Dependencies fehlen (FastAPI/Uvicorn)
 
 **Symptome:**
+
 - `ModuleNotFoundError: No module named 'fastapi'`
 - API-Server startet nicht
 
@@ -74,13 +80,14 @@ pip install --user fastapi uvicorn python-dotenv pydantic
 timeout 120 pip install --user fastapi uvicorn python-dotenv
 
 # Vollständige Requirements (wenn benötigt)
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 timeout 180 pip install --user -r app/requirements.txt
 ```
 
 ### Problem: .env Dateien fehlen
 
 **Symptome:**
+
 - Umgebungsvariablen nicht verfügbar
 - Services starten mit Fehlern
 
@@ -92,13 +99,14 @@ bash .devcontainer/onCreate-setup.sh
 
 # Oder manuell:
 cp .env.example .env
-cp api.menschlichkeit-oesterreich.at/.env.example api.menschlichkeit-oesterreich.at/.env
-cp frontend/.env.example frontend/.env
+cp apps/api/.env.example apps/api/.env
+cp apps/website/.env.example apps/website/.env.local
 ```
 
 ### Problem: npm install schlägt fehl oder hängt
 
 **Symptome:**
+
 - npm install timeout
 - node_modules unvollständig
 - Dependency errors
@@ -123,6 +131,7 @@ npm install --only=production
 ### Problem: Shell-Skripte nicht ausführbar
 
 **Symptome:**
+
 - `Permission denied` beim Ausführen von .sh Dateien
 - Scripts laufen nicht
 
@@ -142,6 +151,7 @@ find . -name "*.sh" -type f -exec chmod +x {} \;
 ### Problem: PowerShell Module fehlen
 
 **Symptome:**
+
 - PowerShell-Funktionen nicht verfügbar
 - Module-Import schlägt fehl
 
@@ -233,12 +243,13 @@ bash .devcontainer/onCreate-setup.sh
 
 # 3. Dependencies neu installieren
 npm install
-cd api.menschlichkeit-oesterreich.at && pip install --user -r app/requirements.txt
+cd apps/api && pip install --user -r app/requirements.txt
 ```
 
 ### Codespace neu erstellen (letzter Ausweg)
 
 Wenn nichts hilft:
+
 1. Codespace löschen (GitHub → Codespaces → Delete)
 2. Neuen Codespace erstellen
 3. Warten bis automatisches Setup abgeschlossen ist
@@ -255,11 +266,12 @@ Wenn nichts hilft:
 ## 🆘 Wenn nichts funktioniert
 
 1. **Issue erstellen**
-   - Repository: github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development
+   - Repository: github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich
    - Template: Bug Report
    - Anhängen: Output von `bash .devcontainer/diagnose.sh`
 
 2. **Direkte Hilfe**
+
    ```bash
    # Manual Setup mit interaktiver Auswahl
    bash .devcontainer/manual-setup.sh

--- a/SECRETS-QUICK-START.md
+++ b/SECRETS-QUICK-START.md
@@ -76,7 +76,7 @@ DATABASE_URL=postgresql://postgres:STRONG_PASSWORD_HERE@localhost:5432/menschlic
 # Migrations ausführen
 npx prisma generate
 npx prisma migrate dev
-cd api.menschlichkeit-oesterreich.at
+cd apps/api
 alembic upgrade head
 ```
 
@@ -113,10 +113,10 @@ start https://github.com/settings/tokens/new
 # 3. "Generate token" klicken → Token kopieren (ghp_...)
 
 # 4. .env aktualisieren
-GH_TOKEN=ghp_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+GH_TOKEN=github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 # 5. GitHub Secret setzen:
-start https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/settings/secrets/actions/new
+start https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/settings/secrets/actions/new
 # Name: GH_TOKEN
 # Secret: ghp_XXX... (aus Schritt 3)
 ```

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -24,8 +24,8 @@ This document provides guidance on how to get support for this project.
 
 1. **Search existing resources:**
    - Check the [Documentation](docs/)
-   - Search [existing Issues](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/issues)
-   - Review [Discussions](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions)
+   - Search [existing Issues](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/issues)
+   - Review [Discussions](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions)
 
 2. **Try debugging:**
    - Enable debug mode: `DEBUG=* npm run dev`
@@ -33,13 +33,14 @@ This document provides guidance on how to get support for this project.
    - Run diagnostics: `npm run quality:gates`
 
 3. **Verify your setup:**
+
    ```bash
    # Check Node.js version
    node --version  # Should be >= 22.0.0
-   
+
    # Check npm version
    npm --version   # Should be >= 10.0.0
-   
+
    # Verify installation
    npm run verify
    ```
@@ -50,9 +51,9 @@ This document provides guidance on how to get support for this project.
 
 For questions, ideas, and general discussion:
 
-- **[Q&A](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions/categories/q-a)** - Ask questions
-- **[Ideas](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions/categories/ideas)** - Suggest improvements
-- **[Show and Tell](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions/categories/show-and-tell)** - Share what you've built
+- **[Q&A](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions/categories/q-a)** - Ask questions
+- **[Ideas](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions/categories/ideas)** - Suggest improvements
+- **[Show and Tell](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions/categories/show-and-tell)** - Share what you've built
 
 #### 🐛 GitHub Issues
 
@@ -98,6 +99,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '...'
 3. See error
@@ -106,9 +108,10 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Environment:**
- - OS: [e.g., macOS 14.1]
- - Node: [e.g., 22.0.0]
- - Browser: [e.g., Chrome 120]
+
+- OS: [e.g., macOS 14.1]
+- Node: [e.g., 22.0.0]
+- Browser: [e.g., Chrome 120]
 
 **Additional context**
 Add any other context about the problem here.
@@ -142,7 +145,7 @@ Please see our [Security Policy](SECURITY.md) for instructions on reporting secu
 - **[README](README.md)** - Project overview and quick start
 - **[Contributing Guide](CONTRIBUTING.md)** - How to contribute
 - **[Architecture Docs](docs/architecture/)** - System architecture
-- **[API Documentation](api.menschlichkeit-oesterreich.at/docs)** - API reference
+- **[API Specification](apps/api/openapi.yaml)** - Source-of-truth API reference for local development
 - **[Deployment Guide](deployment-scripts/README.md)** - Deployment instructions
 
 ### Tutorials & Guides
@@ -186,8 +189,9 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md).
 A: A comprehensive digital platform for democratic participation, education, and community engagement in Austria.
 
 **Q: What technologies does this project use?**  
-A: 
-- **Frontend:** React 18, TypeScript, Tailwind CSS
+A:
+
+- **Frontend:** React 19, TypeScript, Tailwind CSS
 - **Backend:** FastAPI (Python), Node.js
 - **CRM:** Drupal 10 + CiviCRM
 - **Database:** PostgreSQL 16, MariaDB
@@ -203,6 +207,7 @@ A: Use Node.js 22.x LTS or higher. We recommend using [nvm](https://github.com/n
 
 **Q: How do I run the project locally?**  
 A:
+
 ```bash
 npm install
 npm run dev:all
@@ -210,6 +215,7 @@ npm run dev:all
 
 **Q: How do I run tests?**  
 A:
+
 ```bash
 # Unit tests
 npm run test:unit
@@ -223,6 +229,7 @@ npm run test
 
 **Q: How do I check code quality?**  
 A:
+
 ```bash
 npm run quality:gates
 ```
@@ -231,6 +238,7 @@ npm run quality:gates
 
 **Q: How do I deploy to staging?**  
 A:
+
 ```bash
 ./build-pipeline.sh staging
 ```
@@ -240,6 +248,7 @@ A: See the [Deployment Guide](deployment-scripts/README.md) for detailed instruc
 
 **Q: How do I rollback a deployment?**  
 A:
+
 ```bash
 npm run deploy:rollback
 ```
@@ -259,6 +268,7 @@ A: See [Right to Erasure Procedures](docs/compliance/RIGHT-TO-ERASURE-PROCEDURES
 
 **Q: I'm getting "Cannot find module" errors**  
 A: Try:
+
 ```bash
 rm -rf node_modules package-lock.json
 npm install
@@ -266,12 +276,14 @@ npm install
 
 **Q: The development server won't start**  
 A: Check:
+
 1. Is port 3000 already in use?
 2. Are all dependencies installed?
 3. Is your `.env` file configured correctly?
 
 **Q: Tests are failing**  
 A: Try:
+
 ```bash
 npm run test:clean
 npm run test
@@ -279,6 +291,7 @@ npm run test
 
 **Q: Build is failing**  
 A: Try:
+
 ```bash
 npm run clean
 npm run build
@@ -297,9 +310,9 @@ npm run build
 
 ### GitHub
 
-- **Issues:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/issues](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/issues)
-- **Discussions:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions)
-- **Pull Requests:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/pulls](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/pulls)
+- **Issues:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/issues](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/issues)
+- **Discussions:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions)
+- **Pull Requests:** [github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/pulls](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/pulls)
 
 ### Response Times
 
@@ -313,7 +326,7 @@ npm run build
 For complex issues, we offer virtual office hours:
 
 - **When:** Every Friday, 14:00-16:00 CET/CEST
-- **Where:** [GitHub Discussions - Office Hours](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich-development/discussions/categories/office-hours)
+- **Where:** [GitHub Discussions - Office Hours](https://github.com/Menschlichkeit-Osterreich/menschlichkeit-oesterreich/discussions/categories/office-hours)
 - **How:** Post your question beforehand, join the discussion on Friday
 
 ---

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -234,6 +234,8 @@ On Release:
 
 ### Domain Structure
 
+Hinweis: Die folgende Liste beschreibt Laufzeit-Domains in Produktion und Staging. Aktive Entwicklungs- und Source-Pfade im Repository liegen unter `apps/` und `automation/`, insbesondere `apps/website/`, `apps/api/`, `apps/crm/`, `apps/babylon-game/` und `automation/n8n/`.
+
 ```
 menschlichkeit-oesterreich.at/
 ├── www.menschlichkeit-oesterreich.at (Website)

--- a/runbooks/service-restart.md
+++ b/runbooks/service-restart.md
@@ -40,6 +40,8 @@ npm run status:check
 
 ## 2. FastAPI (API Service)
 
+Hinweis: Die Abschnitte unter "Lokal" beschreiben Repository-Pfade und Dev-Kommandos. Die Abschnitte unter "Produktion (Plesk)" beschreiben ausschliesslich Laufzeitpfade auf dem Server und sind keine lokalen Arbeitsverzeichnisse.
+
 ### Lokal (Entwicklung)
 
 ```bash
@@ -90,6 +92,8 @@ npm run build:frontend
 ---
 
 ## 4. CRM (Drupal + CiviCRM)
+
+Hinweis: `crm.menschlichkeit-oesterreich.at` ist hier ein Plesk-Domain-Kontext. Fuer lokale Entwicklung im Repository gilt weiterhin der Source-Pfad `apps/crm/`.
 
 ### Lokal
 


### PR DESCRIPTION
Ziel:
- reine doku-scope-haertung fuer aktive versus legacy-/mirror-pfade, ohne runtime-aenderung

Umfang:
- nur die sechs vereinbarten doku-dateien
- keine produktlogik, keine workflows, keine secret-/deploy-/mail-/slack-logik

Kernanpassungen:
- aktive lokale pfade konsistent auf die apps-struktur gefuehrt, inklusive apps/babylon-game
- legacy-/mirror-/domainpfade nicht mehr als gleichrangige lokale entwicklungsziele formuliert
- klare trennung von lokalem source-scope und produktions-/plesk-laufzeitkontext
- repository-links auf das korrekte github-repo vereinheitlicht

Betroffene Dateien:
- .devcontainer/README.md
- .devcontainer/TROUBLESHOOTING.md
- SUPPORT.md
- SECRETS-QUICK-START.md
- runbooks/service-restart.md
- docs/wiki/Architecture.md

Validierung:
- scope-diff ist auf diese sechs dateien begrenzt
- aenderungen sind rein dokumentationsbasiert