### PR TITLE
chore(deploy): harden plesk secret wiring fail-fast

### DIFF
--- a/.github/workflows/deploy-plesk.yml
+++ b/.github/workflows/deploy-plesk.yml
@@ -43,9 +43,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SSH_HOST: ${{ secrets.PLESK_HOST }}
-  SSH_PORT: ${{ secrets.PLESK_PORT || '22' }}
-  SSH_USER: ${{ secrets.PLESK_USER }}
   BASE_PATH: ${{ vars.PLESK_BASE_PATH || '/var/www/vhosts/menschlichkeit-oesterreich.at/httpdocs' }}
   FRONTEND_REMOTE_PATH: ${{ vars.PLESK_FRONTEND_PATH || 'httpdocs' }}
   API_REMOTE_PATH: ${{ vars.PLESK_API_PATH || 'subdomains/api/httpdocs' }}
@@ -96,21 +93,15 @@ jobs:
 
       - name: Pflicht-Secrets prüfen
         env:
-          HAS_HOST: ${{ secrets.PLESK_HOST != '' }}
-          HAS_USER: ${{ secrets.PLESK_USER != '' }}
-          HAS_KEY: ${{ secrets.PLESK_SSH_PRIVATE_KEY != '' }}
-          HAS_KNOWN_HOSTS: ${{ secrets.PLESK_KNOWN_HOSTS != '' }}
+          HAS_BW_TOKEN: ${{ secrets.BW_ACCESS_TOKEN != '' }}
         run: |
           ERRORS=0
-          [[ "${HAS_HOST}"       == "true" ]] && echo "✓ PLESK_HOST"       || { echo "✗ PLESK_HOST fehlt";             ERRORS=$((ERRORS+1)); }
-          [[ "${HAS_USER}"       == "true" ]] && echo "✓ PLESK_USER"       || { echo "✗ PLESK_USER fehlt";             ERRORS=$((ERRORS+1)); }
-          [[ "${HAS_KEY}"        == "true" ]] && echo "✓ PLESK_SSH_PRIVATE_KEY" || { echo "✗ PLESK_SSH_PRIVATE_KEY fehlt"; ERRORS=$((ERRORS+1)); }
-          [[ "${HAS_KNOWN_HOSTS}" == "true" ]] && echo "✓ PLESK_KNOWN_HOSTS" || { echo "✗ PLESK_KNOWN_HOSTS fehlt";   ERRORS=$((ERRORS+1)); }
+          [[ "${HAS_BW_TOKEN}" == "true" ]] && echo "✓ BW_ACCESS_TOKEN" || { echo "✗ BW_ACCESS_TOKEN fehlt"; ERRORS=$((ERRORS+1)); }
           if (( ERRORS > 0 )); then
             echo "✗ ${ERRORS} Pflicht-Secret(s) fehlen. Deployment abgebrochen."
             exit 1
           fi
-          echo "✓ Alle Pflicht-Secrets vorhanden."
+          echo "✓ Pflicht-Secret fuer BSM vorhanden."
 
   # ============================================================
   # BUILD — Frontend (React + Vite)
@@ -260,6 +251,11 @@ jobs:
           ERRORS=0
 
           required_keys=(
+            PLESK_HOST
+            PLESK_USER
+            PLESK_PORT
+            PLESK_SSH_PRIVATE_KEY
+            PLESK_KNOWN_HOSTS
             DATABASE_URL
             JWT_SECRET_KEY
             STRIPE_SECRET_KEY
@@ -392,6 +388,32 @@ jobs:
           profile: deploy-production
           access_token: ${{ secrets.BW_ACCESS_TOKEN }}
 
+      - name: Plesk-Infra-Kontext aus BSM aufloesen (fail-fast)
+        run: |
+          set -euo pipefail
+          required_keys=(PLESK_HOST PLESK_USER PLESK_PORT PLESK_SSH_PRIVATE_KEY PLESK_KNOWN_HOSTS)
+          for key in "${required_keys[@]}"; do
+            value="${!key:-}"
+            if [ -z "$value" ]; then
+              echo "✗ ${key} fehlt in BSM-Injection"
+              exit 1
+            fi
+            if [[ "$value" =~ ^(CHANGE_ME|PLACEHOLDER|UPDATE_VALUE_IN_VAULT|YOUR_|REPLACE_) ]]; then
+              echo "✗ ${key} enthaelt einen Platzhalterwert"
+              exit 1
+            fi
+            echo "✓ ${key}"
+          done
+
+          if ! [[ "${PLESK_PORT}" =~ ^[0-9]+$ ]]; then
+            echo "✗ PLESK_PORT ist nicht numerisch: ${PLESK_PORT}"
+            exit 1
+          fi
+
+          echo "SSH_HOST=${PLESK_HOST}" >> "$GITHUB_ENV"
+          echo "SSH_USER=${PLESK_USER}" >> "$GITHUB_ENV"
+          echo "SSH_PORT=${PLESK_PORT}" >> "$GITHUB_ENV"
+
       - name: Node.js ${{ env.NODE_VERSION }} einrichten
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.2.0
         with:
@@ -404,23 +426,29 @@ jobs:
           eval "$(ssh-agent -s)"
           echo "SSH_AUTH_SOCK=${SSH_AUTH_SOCK}" >> "$GITHUB_ENV"
           echo "SSH_AGENT_PID=${SSH_AGENT_PID}" >> "$GITHUB_ENV"
-          echo "${{ secrets.PLESK_SSH_PRIVATE_KEY }}" | tr -d '\r' | ssh-add -
+          echo "${PLESK_SSH_PRIVATE_KEY}" | tr -d '\r' | ssh-add -
 
       - name: known_hosts aus Secret eintragen
         run: |
           mkdir -p ~/.ssh
           # Niemals ssh-keyscan in Produktion ohne Verifikation!
-          printf '%s\n' "${{ secrets.PLESK_KNOWN_HOSTS }}" >> ~/.ssh/known_hosts
+          printf '%s\n' "${PLESK_KNOWN_HOSTS}" >> ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
           echo "✓ known_hosts gesetzt."
 
       - name: SSH-Config schreiben
         run: |
+          RESOLVED_SSH_HOST="${PLESK_HOST}"
+          RESOLVED_SSH_PORT="${PLESK_PORT}"
+          RESOLVED_SSH_USER="${PLESK_USER}"
+          echo "SSH_HOST=${RESOLVED_SSH_HOST}" >> "$GITHUB_ENV"
+          echo "SSH_PORT=${RESOLVED_SSH_PORT}" >> "$GITHUB_ENV"
+          echo "SSH_USER=${RESOLVED_SSH_USER}" >> "$GITHUB_ENV"
           cat >> ~/.ssh/config <<EOF
           Host plesk-prod
-            HostName ${{ env.SSH_HOST }}
-            Port ${{ env.SSH_PORT }}
-            User ${{ env.SSH_USER }}
+            HostName ${RESOLVED_SSH_HOST}
+            Port ${RESOLVED_SSH_PORT}
+            User ${RESOLVED_SSH_USER}
             StrictHostKeyChecking yes
             BatchMode yes
             ConnectTimeout 15

--- a/scripts/verify-payment-secret-wiring.ps1
+++ b/scripts/verify-payment-secret-wiring.ps1
@@ -3,39 +3,108 @@ $ErrorActionPreference = 'Stop'
 $repo = Split-Path -Parent $PSScriptRoot
 Set-Location $repo
 
-function Get-EnvState {
+function Test-FileContains {
     param(
         [string]$Path,
-        [string]$Key
+        [string]$Needle
     )
 
-    if (-not (Test-Path $Path)) { return 'missing-file' }
+    if (-not (Test-Path $Path)) {
+        return $false
+    }
 
-    $line = Get-Content $Path | Where-Object { $_ -match ('^' + [regex]::Escape($Key) + '=') } | Select-Object -First 1
-    if (-not $line) { return 'missing-key' }
-
-    $value = ($line -split '=', 2)[1].Trim()
-    if ([string]::IsNullOrWhiteSpace($value)) { return 'empty' }
-    if ($value -match 'PLACEHOLDER|CHANGE_ME') { return 'placeholder' }
-    return 'set'
+    $content = Get-Content -Path $Path -Raw
+    return $content.Contains($Needle)
 }
 
-[PSCustomObject]@{
-    WebsiteStripePublishable    = Get-EnvState 'apps/website/.env.local' 'VITE_STRIPE_PUBLISHABLE_KEY'
-    ApiDatabaseUrl              = Get-EnvState 'apps/api/.env' 'DATABASE_URL'
-    ApiStripeSecret             = Get-EnvState 'apps/api/.env' 'STRIPE_SECRET_KEY'
-    ApiStripeWebhookSecret      = Get-EnvState 'apps/api/.env' 'STRIPE_WEBHOOK_SECRET'
-    ApiAlertsSlackWebhook       = Get-EnvState 'apps/api/.env' 'ALERTS_SLACK_WEBHOOK'
-    ApiMailUsername             = Get-EnvState 'apps/api/.env' 'MAIL_USERNAME'
-    ApiMailPassword             = Get-EnvState 'apps/api/.env' 'MAIL_PASSWORD'
-    ApiMailHost                 = Get-EnvState 'apps/api/.env' 'MAIL_HOST'
-    ApiMailPort                 = Get-EnvState 'apps/api/.env' 'MAIL_PORT'
-    ApiMailEncryption           = Get-EnvState 'apps/api/.env' 'MAIL_ENCRYPTION'
-    ApiMailFromAddress          = Get-EnvState 'apps/api/.env' 'MAIL_FROM_ADDRESS'
-    ApiMailFromName             = Get-EnvState 'apps/api/.env' 'MAIL_FROM_NAME'
-    ApiMailReplyToAddress       = Get-EnvState 'apps/api/.env' 'MAIL_REPLY_TO_ADDRESS'
-    WebsiteLegacyPayPalRemoved  = (Get-EnvState 'apps/website/.env.local' 'VITE_PAYPAL_CLIENT_ID') -eq 'missing-key'
-    ApiLegacyPayPalIdRemoved    = (Get-EnvState 'apps/api/.env' 'PAYPAL_CLIENT_ID') -eq 'missing-key'
-    ApiLegacyPayPalSecretRemoved = (Get-EnvState 'apps/api/.env' 'PAYPAL_CLIENT_SECRET') -eq 'missing-key'
-    BsmOrganizationConfigured   = -not [string]::IsNullOrWhiteSpace($env:BSM_ORGANIZATION_ID)
-} | ConvertTo-Json -Compress
+function Get-ProfileSecretMap {
+    param(
+        [string]$MapPath,
+        [string]$Profile
+    )
+
+    $json = Get-Content -Path $MapPath -Raw | ConvertFrom-Json
+    $profileNode = $json.profiles.$Profile
+    if (-not $profileNode) {
+        throw "BSM profile '$Profile' fehlt in $MapPath"
+    }
+    return $profileNode.secrets
+}
+
+$mapPath = '.github/bsm-secret-ids.json'
+$deployWorkflow = '.github/workflows/deploy-plesk.yml'
+$runtimeContract = 'apps/api/app/runtime_secret_contract.py'
+$mainPath = 'apps/api/app/main.py'
+$paymentsPath = 'apps/api/app/routers/payments.py'
+
+$requiredApiKeys = @(
+    'DATABASE_URL',
+    'JWT_SECRET_KEY',
+    'STRIPE_SECRET_KEY',
+    'STRIPE_WEBHOOK_SECRET',
+    'MOE_API_TOKEN',
+    'N8N_WEBHOOK_SECRET',
+    'CIVICRM_SITE_KEY',
+    'CIVICRM_API_KEY',
+    'ALERTS_SLACK_WEBHOOK',
+    'MICROSOFT_TENANT_ID',
+    'MICROSOFT_CLIENT_ID',
+    'MICROSOFT_CLIENT_SECRET',
+    'MICROSOFT_GRAPH_SENDER'
+)
+
+$requiredInfraKeys = @(
+    'PLESK_HOST',
+    'PLESK_USER',
+    'PLESK_PORT',
+    'PLESK_SSH_PRIVATE_KEY',
+    'PLESK_KNOWN_HOSTS'
+)
+
+$profileSecrets = Get-ProfileSecretMap -MapPath $mapPath -Profile 'deploy-production'
+$profileEnvVars = @($profileSecrets | ForEach-Object { $_.env_var })
+
+$missingApiInProfile = @($requiredApiKeys | Where-Object { $_ -notin $profileEnvVars })
+$missingInfraInProfile = @($requiredInfraKeys | Where-Object { $_ -notin $profileEnvVars })
+
+$placeholderCount = @(
+    $profileSecrets | Where-Object {
+        $_.uuid -match '^(UPDATE_VALUE_IN_VAULT|PLACEHOLDER_)'
+    }
+).Count
+
+$result = [ordered]@{
+    ProfileDeployProductionExists = $true
+    MissingApiKeysInProfile = $missingApiInProfile
+    MissingInfraKeysInProfile = $missingInfraInProfile
+    PlaceholderUuidCount = $placeholderCount
+    RuntimeContractHasStripeSecret = Test-FileContains -Path $runtimeContract -Needle '"STRIPE_SECRET_KEY"'
+    RuntimeContractHasStripeWebhook = Test-FileContains -Path $runtimeContract -Needle '"STRIPE_WEBHOOK_SECRET"'
+    RuntimeContractHasSlackWebhook = Test-FileContains -Path $runtimeContract -Needle '"ALERTS_SLACK_WEBHOOK"'
+    MainEnforcesRuntimeContract = Test-FileContains -Path $mainPath -Needle 'validate_runtime_secret_contract(ENVIRONMENT)'
+    PaymentsUsesSlackSecretProvider = (
+        (Test-FileContains -Path $paymentsPath -Needle 'get_secret(') -and
+        (Test-FileContains -Path $paymentsPath -Needle '"ALERTS_SLACK_WEBHOOK"') -and
+        (Test-FileContains -Path $paymentsPath -Needle 'bsm_key="api/ALERTS_SLACK_WEBHOOK"')
+    )
+    DeployWorkflowUsesBsmInjectedPleskKey = Test-FileContains -Path $deployWorkflow -Needle 'PLESK_SSH_PRIVATE_KEY'
+    DeployWorkflowAvoidsDirectSecretRefs = -not (Test-FileContains -Path $deployWorkflow -Needle 'secrets.PLESK_')
+}
+
+$ok = ($missingApiInProfile.Count -eq 0) -and
+      ($missingInfraInProfile.Count -eq 0) -and
+      ($placeholderCount -eq 0) -and
+      $result.RuntimeContractHasStripeSecret -and
+      $result.RuntimeContractHasStripeWebhook -and
+      $result.RuntimeContractHasSlackWebhook -and
+      $result.MainEnforcesRuntimeContract -and
+      $result.PaymentsUsesSlackSecretProvider -and
+      $result.DeployWorkflowUsesBsmInjectedPleskKey -and
+      $result.DeployWorkflowAvoidsDirectSecretRefs
+
+$result['Pass'] = $ok
+$result | ConvertTo-Json -Depth 5 -Compress
+
+if (-not $ok) {
+    exit 1
+}


### PR DESCRIPTION
## Scope

Dieser PR enthält exakt zwei Dateien:

- .github/workflows/deploy-plesk.yml
- scripts/verify-payment-secret-wiring.ps1

Keine weiteren Dateien sind Teil dieses PR-Scope.

## Änderungen

- Deploy-Workflow auf BSM-basierte Plesk-Infra-Auflösung mit fail-fast Validierung gehärtet
- direkte secrets.PLESK_* Nutzung im Workflow entfernt
- Verifikationsskript auf Contract-/Wiring-Prüfung mit hartem Fail refaktoriert

## Finaler Verifikationsstatus

- pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File scripts/verify-payment-secret-wiring.ps1 -> Pass: true
- keine direkte secrets.PLESK_* Nutzung mehr in .github/workflows/deploy-plesk.yml

## Prüfkriterien

- PR enthält nur:
  - .github/workflows/deploy-plesk.yml
  - scripts/verify-payment-secret-wiring.ps1
- Verifikationsstatus ist dokumentiert
- Keine weiteren Nacharbeiten oder Scope-Erweiterungen enthalten