### PR TITLE
Hotfix: E2E Phase 1 Navigation - Minimal Scope Isolate from PR #322

### DIFF
--- a/tests/e2e/authentication.spec.ts
+++ b/tests/e2e/authentication.spec.ts
@@ -38,6 +38,7 @@ test.describe('Authentication E2E Tests', () => {
    */
   test('Valid login with existing credentials should redirect to dashboard', async ({ page }) => {
     // Navigate to login page
+    await page.goto(`${BASE_URL}/login`);
 
     // On public host, /login renders cross-host redirect/fallback instead of form
     if (await isPortalFallbackVisible(page)) {

--- a/tests/e2e/donation-flow.spec.ts
+++ b/tests/e2e/donation-flow.spec.ts
@@ -26,6 +26,7 @@ test.describe('Donation Payment Flow E2E Tests', () => {
    */
   test('Browse donate page and select amount', async ({ page }) => {
     // Navigate to donate page
+    await page.goto(`${BASE_URL}/spenden`);
 
     // Verify donate page elements
     await expect(page.locator('h1')).toContainText(/donate|spende|spenden/i);


### PR DESCRIPTION
## Minimal E2E Navigation Hotfix

This is an isolated minimal hotfix for the confirmed E2E Phase 1 (Chromium) blocker.

**Changes:**
- tests/e2e/authentication.spec.ts: Add missing page.goto(`${BASE_URL}/login`) navigation
- tests/e2e/donation-flow.spec.ts: Add missing page.goto(`${BASE_URL}/spenden`) navigation

**Scope:** 2 files changed, 2 insertions - ONLY E2E test fixes

**Explicitly excluded from this PR:**
- docker-compose.yml changes
- Dockerfile modifications  
- init-drupal.sh updates
- Nginx default.conf setup
- Security rotation gate scripts
- README updates
- Any CRM, deploy, or infrastructure changes

This is intentionally isolated from PR #322's broader scope to enable release without accumulating unrelated work.

**Expected CI Result:**
- E2E Phase 1 (Chromium) should PASS (verified from commit f77753ffe)